### PR TITLE
Longtitude and lattitude fix when using manual position.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -53,7 +53,7 @@ const RedshiftToggle = new Lang.Class({
             if (provider == "manual") {
                 let lat = this._settings.get_double(RedshiftUtil.REDSHIFT_LOCATION_LATITUDE_KEY);
                 let lon = this._settings.get_double(RedshiftUtil.REDSHIFT_LOCATION_LONGITUDE_KEY);
-                command.push("-l " + lon + ":" + lat);
+                command.push("-l " + lat + ":" + lon);
             } else {
                 command.push("-l" + provider);
             }

--- a/src/extension.js
+++ b/src/extension.js
@@ -60,7 +60,6 @@ const RedshiftToggle = new Lang.Class({
             let tempDay = this._settings.get_int(RedshiftUtil.REDSHIFT_TEMPERATURE_DAYTIME_KEY);
             let tempNight = this._settings.get_int(RedshiftUtil.REDSHIFT_TEMPERATURE_NIGHTTIME_KEY);
             command.push("-t " + tempDay + ":" + tempNight);
-            command.push("-r");
             
             let [success, pid] = GLib.spawn_async(null, command, null,
                              GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.DO_NOT_REAP_CHILD,

--- a/src/extension.js
+++ b/src/extension.js
@@ -60,6 +60,7 @@ const RedshiftToggle = new Lang.Class({
             let tempDay = this._settings.get_int(RedshiftUtil.REDSHIFT_TEMPERATURE_DAYTIME_KEY);
             let tempNight = this._settings.get_int(RedshiftUtil.REDSHIFT_TEMPERATURE_NIGHTTIME_KEY);
             command.push("-t " + tempDay + ":" + tempNight);
+            command.push("-r");
             
             let [success, pid] = GLib.spawn_async(null, command, null,
                              GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.DO_NOT_REAP_CHILD,


### PR DESCRIPTION
I noticed that this extension is using wrong coordinates, which resulted in switching to the night mode when it's a daylight. The problem appears to be in the -l option. It's the other way around - lattitude comes first.

From man: -l LAT:LON