### PR TITLE
added 3.14 and 3.16 as supported versions

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -4,6 +4,6 @@
 "description": "Integrate redshift toggle into the user menu",
 "original-author": "thomas@tommie-lie.de",
 "url": "https://github.com/tommie-lie/gnome-shell-extension-redshift",
-"shell-version": [ "3.6", "3.8", "3.12" ],
+"shell-version": [ "3.6", "3.8", "3.12", "3.14", "3.16" ],
 "settings-schema": "org.gnome.shell.extensions.redshift"
 }


### PR DESCRIPTION
I also confirmed it works as expected in 3.14 and 3.16 (Ubuntu GNOME). It looks good and usable so I don't see a reason not to enable it for these versions.